### PR TITLE
Rework resource mapping and polymorphism

### DIFF
--- a/src/__tests__/__snapshots__/openapi.test.js.snap
+++ b/src/__tests__/__snapshots__/openapi.test.js.snap
@@ -55,6 +55,7 @@ Object {
           "x-nullable": false,
         },
       },
+      "type": "object",
     },
     "Foo": Object {
       "properties": Object {
@@ -93,7 +94,7 @@ Object {
         },
         "items": Object {
           "items": Object {
-            "$ref": "#/definitions/Foo",
+            "$ref": "#Foo",
           },
           "type": "array",
           "x-nullable": false,
@@ -607,6 +608,7 @@ Object {
             "type": "integer",
           },
         },
+        "type": "object",
       },
       "Foo": Object {
         "properties": Object {
@@ -645,7 +647,7 @@ Object {
           },
           "items": Object {
             "items": Object {
-              "$ref": "#/components/schemas/Foo",
+              "$ref": "#Foo",
             },
             "nullable": false,
             "type": "array",

--- a/src/__tests__/app.js
+++ b/src/__tests__/app.js
@@ -33,8 +33,23 @@ import {
     UpdateFoo,
 } from './resources';
 
-export default function createApp() {
+export function newApp({ operations }) {
     const app = express();
+
+    app.use(cors());
+    app.use(express.json());
+
+    operations.forEach((operation) => {
+        operation.register(app);
+    });
+
+    app.get('/openapi/2.0', serveSpec({ openapiVersion: '2.0', operations }));
+    app.get('/openapi/3.0.0', serveSpec({ openapiVersion: '3.0.0', operations }));
+
+    return app;
+}
+
+export default function createApp() {
     const operations = [
         new Create({ input: CreateFoo, output: Foo, route: routes.create, resourceName: 'foo' }),
         new Count({ input: CountFoo, route: routes.count, resourceName: 'foo' }),
@@ -64,17 +79,7 @@ export default function createApp() {
         }),
     ];
 
-    app.use(cors());
-    app.use(express.json());
-
-    operations.forEach((operation) => {
-        operation.register(app);
-    });
-
-    app.get('/openapi/2.0', serveSpec({ openapiVersion: '2.0', operations }));
-    app.get('/openapi/3.0.0', serveSpec({ openapiVersion: '3.0.0', operations }));
-
-    return app;
+    return newApp({ operations });
 }
 
 if (require.main === module) {

--- a/src/__tests__/fixtures.js
+++ b/src/__tests__/fixtures.js
@@ -1,0 +1,51 @@
+import { JSONSchemaResource } from '..';
+
+export const PetType = Object.freeze({
+    cat: 'cat',
+    dog: 'dog',
+});
+
+export const CatInfo = JSONSchemaResource.all({
+    id: 'CatInfo',
+    properties: {
+        lives: {
+            type: 'integer',
+        },
+    },
+});
+
+export const DogInfo = JSONSchemaResource.all({
+    id: 'DogInfo',
+    properties: {
+        bestFriend: {
+            type: 'string',
+        },
+    },
+});
+
+export const Pet = JSONSchemaResource.all({
+    id: 'Pet',
+    properties: {
+        name: {
+            type: 'string',
+        },
+        type: {
+            type: 'string',
+            enum: Object.keys(PetType).sort(),
+        },
+        info: {
+            anyOf: [
+                /*
+                {
+                    $ref: '#CatInfo',
+                },
+                {
+                    $ref: '#DogInfo',
+                },
+                */
+                CatInfo.schema,
+                DogInfo.schema,
+            ],
+        },
+    },
+}).addReference(CatInfo).addReference(DogInfo);

--- a/src/__tests__/polymorphic.test.js
+++ b/src/__tests__/polymorphic.test.js
@@ -1,0 +1,123 @@
+import request from 'supertest';
+
+import { Create, Search } from '..';
+import { newApp } from './app';
+import { Pet, PetType } from './fixtures';
+
+function create(pet) {
+    return pet;
+}
+
+function search() {
+    return {
+        count: 2,
+        items: [{
+            additionalProperty: 'ignore',
+            info: {
+                lives: 9,
+            },
+            name: 'Felix',
+            type: PetType.cat,
+        }, {
+            additionalProperty: 'ignore',
+            info: {
+                bestFriend: 'man',
+            },
+            name: 'Rex',
+            type: PetType.dog,
+        }],
+    };
+}
+
+describe('polymorphic schema', () => {
+    let app;
+
+    beforeEach(() => {
+        const operations = [
+            new Create({ input: Pet, output: Pet, resourceName: 'pet', route: create }),
+            new Search({ output: Pet.toList(), resourceName: 'pet', route: search }),
+        ];
+        app = newApp({ operations });
+    });
+
+    describe('search', () => {
+        it('returns polymorphic properties', async () => {
+            const response = await request(app).get('/pet');
+            expect(response.statusCode).toEqual(200);
+            expect(response.body.count).toEqual(2);
+            expect(response.body.items.length).toEqual(2);
+            expect(response.body.items[0].additionalProperty).not.toBeDefined();
+            expect(response.body.items[0].info).toEqual({ lives: 9 });
+            expect(response.body.items[0].name).toEqual('Felix');
+            expect(response.body.items[0].type).toEqual(PetType.cat);
+            expect(response.body.items[1].info).toEqual({ bestFriend: 'man' });
+            expect(response.body.items[1].name).toEqual('Rex');
+            expect(response.body.items[1].type).toEqual(PetType.dog);
+        });
+    });
+
+    describe('create', () => {
+        it('supports well-formed cats', async () => {
+            const response = await request(app).post('/pet').send({
+                info: {
+                    lives: 9,
+                },
+                name: 'Felix',
+                type: PetType.cat,
+            });
+            expect(response.statusCode).toEqual(201);
+        });
+        it('validates malformed cats', async () => {
+            const response = await request(app).post('/pet').send({
+                info: {
+                    lives: 'nine',
+                },
+                name: 'Felix',
+                type: PetType.cat,
+            });
+            expect(response.statusCode).toEqual(422);
+        });
+        it('validates cats with additional properties', async () => {
+            const response = await request(app).post('/pet').send({
+                info: {
+                    landsOnFeet: true,
+                    lives: 9,
+                },
+                name: 'Felix',
+                type: PetType.cat,
+            });
+            expect(response.statusCode).toEqual(422);
+        });
+        it('supports well-formed dogs', async () => {
+            const response = await request(app).post('/pet').send({
+                info: {
+                    bestFriend: 'man',
+                },
+                name: 'Rex',
+                type: PetType.dog,
+            });
+            expect(response.statusCode).toEqual(201);
+        });
+        it('validates malformed dogs', async () => {
+            const response = await request(app).post('/pet').send({
+                info: {
+                    bestFriend: true,
+                },
+                name: 'Rex',
+                type: PetType.dog,
+            });
+            expect(response.statusCode).toEqual(422);
+        });
+        it('validates cats with additional properties', async () => {
+            const response = await request(app).post('/pet').send({
+                info: {
+                    chasesTail: true,
+                    bestFriend: 'man',
+                },
+                name: 'Rex',
+                type: PetType.dog,
+            });
+            expect(response.statusCode).toEqual(422);
+        });
+    });
+});

--- a/src/handler/__tests__/handler.test.js
+++ b/src/handler/__tests__/handler.test.js
@@ -139,8 +139,7 @@ describe('handler', () => {
                 items: [
                     {
                         name: 'name',
-                        // XXX TODO: fix resource castOutput
-                        bar: undefined,
+                        bar: 'whatever',
                     },
                 ],
             };
@@ -149,7 +148,8 @@ describe('handler', () => {
                 flag: true,
                 items: [
                     {
-                        name: 'name',
+                        name: undefined,
+                        bar: undefined,
                     },
                 ],
             });

--- a/src/handler/handler.js
+++ b/src/handler/handler.js
@@ -12,17 +12,17 @@ function deepOmitUndefined(object) {
         );
     }
 
-    return omitBy(
-        mapValues(
-            object,
-            (value) => (
-                isPlainObject(value)
-                    ? deepOmitUndefined(value)
-                    : value
+    if (isPlainObject(object)) {
+        return omitBy(
+            mapValues(
+                object,
+                (value) => deepOmitUndefined(value),
             ),
-        ),
-        isUndefined,
-    );
+            isUndefined,
+        );
+    }
+
+    return object;
 }
 
 

--- a/src/operation/response.js
+++ b/src/operation/response.js
@@ -2,7 +2,7 @@ import { NO_CONTENT } from 'http-status-codes';
 import { mapValues } from 'lodash';
 
 import { JSON_MIMETYPE } from '../constants';
-import File from '../resource/file';
+import FileType from '../resource/file';
 import buildVersion from '../versions';
 
 /* Represents an OpenAPI Response.
@@ -99,7 +99,7 @@ export default class Response {
             description: `${resourceName} file content`,
             headers,
             name: statusCode,
-            file: new File(),
+            file: new FileType(),
         });
     }
 }

--- a/src/resource/config.js
+++ b/src/resource/config.js
@@ -1,8 +1,8 @@
-/* Resource configuration.
- */
 import DefaultNamingStrategy from './naming';
 import DefaultPagingStrategy from './paging';
 
+/* Resource configuration enables overriding naming and paging strategies.
+ */
 export default class ResourceConfig {
     constructor(options = {}) {
         const {

--- a/src/resource/file.js
+++ b/src/resource/file.js
@@ -1,6 +1,8 @@
 import buildVersion from '../versions';
 
-export default class File {
+/* The type for a resource that uses a file.
+ */
+export default class FileType {
     build(openapiVersion) {
         return buildVersion(this, openapiVersion);
     }

--- a/src/resource/jsonschema/__tests__/fixtures.js
+++ b/src/resource/jsonschema/__tests__/fixtures.js
@@ -1,0 +1,71 @@
+import JSONSchemaResource from '..';
+
+export const ChildSchema = JSONSchemaResource.all({
+    id: 'Child',
+    properties: {
+        value: {
+            type: 'string',
+        },
+    },
+});
+
+export const StringValueSchema = JSONSchemaResource.all({
+    id: 'StringValue',
+    properties: {
+        value: {
+            type: 'string',
+        },
+    },
+});
+
+export const StringValueListSchema = JSONSchemaResource.all({
+    id: 'StringValueList',
+    properties: {
+        value: {
+            type: 'array',
+            items: {
+                type: 'string',
+            },
+        },
+    },
+});
+
+export const NestedStringValueSchema = JSONSchemaResource.all({
+    id: 'NestedStringValue',
+    properties: {
+        value: {
+            type: 'object',
+            properties: {
+                value: {
+                    type: 'string',
+                },
+                required: [
+                    'value',
+                ],
+            },
+        },
+    },
+});
+
+export const NestedReferenceSchema = JSONSchemaResource.all({
+    id: 'NestedReference',
+    properties: {
+        value: {
+            // XXX $ref: ChildSchema.toRef(),
+            $ref: '#Child',
+        },
+    },
+}).addReference(ChildSchema);
+
+export const NestedReferenceListSchema = JSONSchemaResource.all({
+    id: 'NestedReferenceList',
+    properties: {
+        value: {
+            type: 'array',
+            items: {
+                // XXX $ref: ChildSchema.toRef(),
+                $ref: '#Child',
+            },
+        },
+    },
+}).addReference(ChildSchema);

--- a/src/resource/jsonschema/__tests__/jsonschema.test.js
+++ b/src/resource/jsonschema/__tests__/jsonschema.test.js
@@ -101,7 +101,7 @@ describe('JSONSchemaResource', () => {
     });
 
     describe('castInput()', () => {
-        it('undefines unmapped properties', () => {
+        it('preserves unmapped properties', () => {
             const data = {
                 nullableString: null,
                 foo: 'bar',
@@ -109,6 +109,7 @@ describe('JSONSchemaResource', () => {
             const input = resource.castInput(data);
             expect(input).toEqual({
                 nullableString: null,
+                foo: 'bar',
             });
         });
         it('converts mapped properties', () => {

--- a/src/resource/jsonschema/__tests__/map.test.js
+++ b/src/resource/jsonschema/__tests__/map.test.js
@@ -1,0 +1,109 @@
+import mapSchema from '../map';
+import {
+    NestedReferenceListSchema,
+    NestedReferenceSchema,
+    NestedStringValueSchema,
+    StringValueSchema,
+    StringValueListSchema,
+} from './fixtures';
+
+function isDefined(object, schema) {
+    return schema !== null;
+}
+
+describe('mapSchema', () => {
+    describe('StringValueSchema', () => {
+        it('maps property values', () => {
+            const schema = StringValueSchema;
+            const object = {
+                additionalProperty: 'additionalProperty',
+                value: 'string',
+            };
+            const mapping = mapSchema(object, schema, schema.registry, isDefined);
+            expect(mapping).toEqual({
+                additionalProperty: false,
+                value: true,
+            });
+        });
+    });
+    describe('StringValueListSchema', () => {
+        it('maps property values', () => {
+            const schema = StringValueListSchema;
+            const object = {
+                additionalProperty: 'additionalProperty',
+                value: [
+                    'string1',
+                    'string2',
+                ],
+            };
+            const mapping = mapSchema(object, schema, schema.registry, isDefined);
+            expect(mapping).toEqual({
+                additionalProperty: false,
+                value: [
+                    true,
+                    true,
+                ],
+            });
+        });
+    });
+    describe('NestedStringValueSchema', () => {
+        it('maps property values', () => {
+            const schema = NestedStringValueSchema;
+            const object = {
+                additionalProperty: 'additionalProperty',
+                value: {
+                    additionalProperty: 'additionalProperty',
+                    value: 'string',
+                },
+            };
+            const mapping = mapSchema(object, schema, schema.registry, isDefined);
+            expect(mapping).toEqual({
+                additionalProperty: false,
+                value: {
+                    additionalProperty: false,
+                    value: true,
+                },
+            });
+        });
+    });
+    describe('NestedReferenceSchema', () => {
+        it('maps property values', () => {
+            const schema = NestedReferenceSchema;
+            const object = {
+                additionalProperty: 'additionalProperty',
+                value: {
+                    additionalProperty: 'additionalProperty',
+                    value: 'string',
+                },
+            };
+            const mapping = mapSchema(object, schema, schema.registry, isDefined);
+            expect(mapping).toEqual({
+                additionalProperty: false,
+                value: {
+                    additionalProperty: false,
+                    value: true,
+                },
+            });
+        });
+    });
+    describe('NestedReferenceListSchema', () => {
+        it('maps property values', () => {
+            const schema = NestedReferenceListSchema;
+            const object = {
+                additionalProperty: 'additionalProperty',
+                value: [{
+                    additionalProperty: 'additionalProperty',
+                    value: 'string',
+                }],
+            };
+            const mapping = mapSchema(object, schema, schema.registry, isDefined);
+            expect(mapping).toEqual({
+                additionalProperty: false,
+                value: [{
+                    additionalProperty: false,
+                    value: true,
+                }],
+            });
+        });
+    });
+});

--- a/src/resource/jsonschema/list.js
+++ b/src/resource/jsonschema/list.js
@@ -1,45 +1,54 @@
 import JSONSchemaResource from './resource';
 
+/* A resource that represents a list of another resource.
+ */
 export default class JSONSchemaListResource extends JSONSchemaResource {
     constructor(item) {
-        super(JSONSchemaListResource.createSchema(item), item.config);
+        const schema = JSONSchemaListResource.createSchema(item);
+        super(schema, item.options);
         this.item = item;
+        this.addReference(item);
     }
 
+    /* Create a new JSONSchema represention for a list of items.
+     */
     static createSchema(item) {
         const { config } = item;
-        const properties = {
-            items: {
-                type: 'array',
-                items: item.toRef(),
+        const { namingStrategy, pagingStrategy } = config;
+        const schema = {
+            id: namingStrategy.toListName(item.id),
+            type: 'object',
+            properties: {
+                items: {
+                    type: 'array',
+                    items: {
+                        // XXX fix references
+                        $ref: `#${item.id}`,
+                    },
+                },
             },
+            required: [
+                'items',
+            ],
         };
-        const required = [
-            'items',
-        ];
 
         // enable response to report on current offset/limit paging
-        if (config.pagingStrategy.hasOffsetLimit) {
-            properties.limit = {
+        if (pagingStrategy.hasOffsetLimit) {
+            schema.properties.limit = {
                 type: 'integer',
             };
-            properties.offset = {
+            schema.properties.offset = {
                 type: 'integer',
             };
         }
         // enable response to report on total collection count
-        if (config.pagingStrategy.hasCount) {
-            properties.count = {
+        if (pagingStrategy.hasCount) {
+            schema.properties.count = {
                 type: 'integer',
             };
-            required.push('count');
+            schema.required.push('count');
         }
 
-        return {
-            id: config.namingStrategy.toListName(item.id),
-            type: 'object',
-            properties,
-            required,
-        };
+        return schema;
     }
 }

--- a/src/resource/jsonschema/map.js
+++ b/src/resource/jsonschema/map.js
@@ -1,0 +1,49 @@
+import { get, mapValues } from 'lodash';
+
+/* Map a function over an object and a schema.
+ */
+export default function mapSchema(value, schema, registry, func, path = '') {
+    if (!schema) {
+        return func(value, null);
+    }
+
+    const { $ref, type } = schema;
+
+    if ($ref) {
+        // XXX resolved Reference
+        return mapSchema(
+            value,
+            registry[$ref],
+            registry,
+            func,
+            `${path}.$ref`,
+        );
+    }
+
+    if (type === 'array') {
+        return value.map(
+            (child) => mapSchema(
+                child,
+                get(schema, 'items'),
+                registry,
+                func,
+                `${path}.items`,
+            ),
+        );
+    }
+
+    if (type === 'object') {
+        return mapValues(
+            value,
+            (child, key) => mapSchema(
+                child,
+                get(schema, `properties.${key}`),
+                registry,
+                func,
+                `${path}.properties.${key}`,
+            ),
+        );
+    }
+
+    return func(value, schema);
+}

--- a/src/resource/jsonschema/property.js
+++ b/src/resource/jsonschema/property.js
@@ -1,5 +1,6 @@
 import { merge, omit } from 'lodash';
 
+import Reference from '../reference';
 import { OPENAPI_2_0 } from '../../constants';
 
 /* Does this schema have a nullable type?
@@ -26,8 +27,10 @@ export function buildProperty(schema, openapiVersion) {
         : type;
 
     // special case #3: items is a reference to another part of the document
-    if (items) {
+    if (items instanceof Reference) {
         converted.items = items.build(openapiVersion);
+    } else {
+        converted.items = items;
     }
 
     return merge(

--- a/src/resource/jsonschema/types.js
+++ b/src/resource/jsonschema/types.js
@@ -1,7 +1,7 @@
 /* Cast a JSON value to a JSON Schema primitive type.
  */
-export function castInputValue(value, property) {
-    const { format, type } = property;
+export function castInputValue(value, schema) {
+    const { format, type } = schema;
 
     if (type === 'integer' || type === 'long') {
         return parseInt(value, 10);

--- a/src/resource/paging.js
+++ b/src/resource/paging.js
@@ -1,8 +1,13 @@
 /* Define how resources collections will paginate.
  */
 export default class DefaultPagingStrategy {
-    constructor() {
-        this.hasCount = true;
-        this.hasOffsetLimit = true;
+    constructor(options = {}) {
+        const {
+            hasCount = true,
+            hasOffsetLimit = true,
+        } = options;
+
+        this.hasCount = hasCount;
+        this.hasOffsetLimit = hasOffsetLimit;
     }
 }

--- a/src/resource/reference.js
+++ b/src/resource/reference.js
@@ -1,5 +1,7 @@
 import buildVersion from '../versions';
 
+/* A reference to a resource.
+ */
 export default class Reference {
     constructor(id) {
         this.id = id;

--- a/src/resource/resource.js
+++ b/src/resource/resource.js
@@ -3,8 +3,18 @@ import ResourceConfig from './config';
 /* A resource defines a contract for the inputs and outputs of Operations.
  */
 export default class Resource {
-    constructor(config) {
+    constructor(options = {}) {
+        const { config, registry } = options;
+
         this.config = config || new ResourceConfig();
+        this.registry = registry || {};
+    }
+
+    get options() {
+        return {
+            config: this.config,
+            registry: this.registry,
+        };
     }
 
     get keys() { // eslint-disable-line class-methods-use-this


### PR DESCRIPTION
Replaces `deepCast` with a generalized and well-tested `mapSchema` function that
traverses an object and a schema together and runs through a function. At the same
time, fix the `omitUndefined` function to properly recurse and build a number of
better tests for polymorphic resources.

Unfortunately, this logic required a bit of work around how to resolved `$ref`
types, which I chose to punt on until a new PR. So this version should not be
released yet.