### PR TITLE
Rework reference implementation.

### DIFF
--- a/src/__tests__/__snapshots__/openapi.test.js.snap
+++ b/src/__tests__/__snapshots__/openapi.test.js.snap
@@ -94,7 +94,7 @@ Object {
         },
         "items": Object {
           "items": Object {
-            "$ref": "#Foo",
+            "$ref": "#/definitions/Foo",
           },
           "type": "array",
           "x-nullable": false,
@@ -647,7 +647,7 @@ Object {
           },
           "items": Object {
             "items": Object {
-              "$ref": "#Foo",
+              "$ref": "#/components/schemas/Foo",
             },
             "nullable": false,
             "type": "array",

--- a/src/__tests__/fixtures.js
+++ b/src/__tests__/fixtures.js
@@ -48,4 +48,4 @@ export const Pet = JSONSchemaResource.all({
             ],
         },
     },
-}).addReference(CatInfo).addReference(DogInfo);
+});

--- a/src/operation/operation.js
+++ b/src/operation/operation.js
@@ -124,7 +124,9 @@ export default class Operation {
                     required: true,
                     content: {
                         [this.consumes || DEFAULT_PRODUCES]: {
-                            schema: this.input.toRef().build(openapiVersion),
+                            schema: {
+                                $ref: this.input.toRef().build(openapiVersion),
+                            },
                         },
                     },
                 }

--- a/src/operation/parameter.js
+++ b/src/operation/parameter.js
@@ -20,7 +20,7 @@ export default class Parameter {
             name: this.name,
             in: this.parameterType,
             required: this.required,
-            schema: this.ref ? this.ref.build(openapiVersion) : undefined,
+            schema: this.ref ? { $ref: this.ref.build(openapiVersion) } : undefined,
             type: this.type,
         };
     }

--- a/src/operation/response.js
+++ b/src/operation/response.js
@@ -51,7 +51,9 @@ export default class Response {
     buildSchema(openapiVersion) {
         if (this.contentType === JSON_MIMETYPE) {
             if (this.ref) {
-                return this.ref.build(openapiVersion);
+                return {
+                    $ref: this.ref.build(openapiVersion),
+                };
             }
         } else if (this.file) {
             return this.file.build(openapiVersion);

--- a/src/resource/__tests__/reference.test.js
+++ b/src/resource/__tests__/reference.test.js
@@ -3,14 +3,10 @@ import Reference from '../reference';
 describe('Reference', () => {
     describe('build', () => {
         it('returns valid OpenAPI 2.0', () => {
-            expect(new Reference('Foo').build('2.0')).toEqual({
-                $ref: '#/definitions/Foo',
-            });
+            expect(new Reference({ id: 'Foo' }).build('2.0')).toEqual('#/definitions/Foo');
         });
         it('returns valid OpenAPI 3.0.0', () => {
-            expect(new Reference('Foo').build('3.0.0')).toEqual({
-                $ref: '#/components/schemas/Foo',
-            });
+            expect(new Reference({ id: 'Foo' }).build('3.0.0')).toEqual('#/components/schemas/Foo');
         });
     });
 });

--- a/src/resource/jsonschema/__tests__/fixtures.js
+++ b/src/resource/jsonschema/__tests__/fixtures.js
@@ -51,11 +51,10 @@ export const NestedReferenceSchema = JSONSchemaResource.all({
     id: 'NestedReference',
     properties: {
         value: {
-            // XXX $ref: ChildSchema.toRef(),
-            $ref: '#Child',
+            $ref: ChildSchema.toRef(),
         },
     },
-}).addReference(ChildSchema);
+});
 
 export const NestedReferenceListSchema = JSONSchemaResource.all({
     id: 'NestedReferenceList',
@@ -63,9 +62,8 @@ export const NestedReferenceListSchema = JSONSchemaResource.all({
         value: {
             type: 'array',
             items: {
-                // XXX $ref: ChildSchema.toRef(),
-                $ref: '#Child',
+                $ref: ChildSchema.toRef(),
             },
         },
     },
-}).addReference(ChildSchema);
+});

--- a/src/resource/jsonschema/__tests__/map.test.js
+++ b/src/resource/jsonschema/__tests__/map.test.js
@@ -19,7 +19,7 @@ describe('mapSchema', () => {
                 additionalProperty: 'additionalProperty',
                 value: 'string',
             };
-            const mapping = mapSchema(object, schema, schema.registry, isDefined);
+            const mapping = mapSchema(object, schema, isDefined);
             expect(mapping).toEqual({
                 additionalProperty: false,
                 value: true,
@@ -36,7 +36,7 @@ describe('mapSchema', () => {
                     'string2',
                 ],
             };
-            const mapping = mapSchema(object, schema, schema.registry, isDefined);
+            const mapping = mapSchema(object, schema, isDefined);
             expect(mapping).toEqual({
                 additionalProperty: false,
                 value: [
@@ -56,7 +56,7 @@ describe('mapSchema', () => {
                     value: 'string',
                 },
             };
-            const mapping = mapSchema(object, schema, schema.registry, isDefined);
+            const mapping = mapSchema(object, schema, isDefined);
             expect(mapping).toEqual({
                 additionalProperty: false,
                 value: {
@@ -76,7 +76,7 @@ describe('mapSchema', () => {
                     value: 'string',
                 },
             };
-            const mapping = mapSchema(object, schema, schema.registry, isDefined);
+            const mapping = mapSchema(object, schema, isDefined);
             expect(mapping).toEqual({
                 additionalProperty: false,
                 value: {
@@ -96,7 +96,7 @@ describe('mapSchema', () => {
                     value: 'string',
                 }],
             };
-            const mapping = mapSchema(object, schema, schema.registry, isDefined);
+            const mapping = mapSchema(object, schema, isDefined);
             expect(mapping).toEqual({
                 additionalProperty: false,
                 value: [{

--- a/src/resource/jsonschema/list.js
+++ b/src/resource/jsonschema/list.js
@@ -7,7 +7,6 @@ export default class JSONSchemaListResource extends JSONSchemaResource {
         const schema = JSONSchemaListResource.createSchema(item);
         super(schema, item.options);
         this.item = item;
-        this.addReference(item);
     }
 
     /* Create a new JSONSchema represention for a list of items.
@@ -22,8 +21,7 @@ export default class JSONSchemaListResource extends JSONSchemaResource {
                 items: {
                     type: 'array',
                     items: {
-                        // XXX fix references
-                        $ref: `#${item.id}`,
+                        $ref: item.toRef(),
                     },
                 },
             },

--- a/src/resource/jsonschema/property.js
+++ b/src/resource/jsonschema/property.js
@@ -1,7 +1,7 @@
 import { merge, omit } from 'lodash';
 
-import Reference from '../reference';
 import { OPENAPI_2_0 } from '../../constants';
+import Reference from '../reference';
 
 /* Does this schema have a nullable type?
  */
@@ -27,8 +27,10 @@ export function buildProperty(schema, openapiVersion) {
         : type;
 
     // special case #3: items is a reference to another part of the document
-    if (items instanceof Reference) {
-        converted.items = items.build(openapiVersion);
+    if (items && items.$ref && items.$ref instanceof Reference) {
+        converted.items = {
+            $ref: items.$ref.build(openapiVersion),
+        };
     } else {
         converted.items = items;
     }

--- a/src/resource/jsonschema/validator.js
+++ b/src/resource/jsonschema/validator.js
@@ -1,0 +1,65 @@
+import { isPlainObject, mapValues } from 'lodash';
+import { Validator } from 'jsonschema';
+
+import Reference from '../reference';
+
+/* Replace `Reference` instances in the schema with an concrete path.
+ *
+ * OpenAPI 2.0 and 3.0.0 expect different root paths for resources. We avoid committing
+ * to one path or another by using a `Reference` object instance and deferring spec building
+ * until as late as possible.
+ *
+ * However, internal references may be needed for resource validation, so we replace
+ * `Reference` instances with a _generic_ path during validation.
+ */
+function dereference(object, validator, path = '') {
+    // recurse into lists
+    if (Array.isArray(object)) {
+        return object.map(
+            (item) => dereference(item, validator, `${path}[]`),
+        );
+    }
+
+    // recurse into objects
+    if (isPlainObject(object)) {
+        return mapValues(
+            object,
+            (value, key) => {
+                if (key !== '$ref') {
+                    // not a ref
+                    return dereference(value, validator, `${path}.${key}`);
+                }
+                if (!(value instanceof Reference)) {
+                    // not a valid ref
+                    throw new Error('Expected $ref to be instance of Reference; did you use Resource.toRef()?');
+                }
+
+                // use '/foo' as the generic reference path
+                const refId = `/${value.id}`;
+
+                // recurse to the referenced schema
+                const referenceSchema = dereference(value.resource.schema, validator);
+
+                // save the reference schema under the reference id *locally* within this validator.
+                validator.addSchema(referenceSchema, refId);
+
+                // return the generic reference path in place of the Reference
+                return refId;
+            },
+        );
+    }
+
+    // base case
+    return object;
+}
+
+/* Create a JSON Schema validator for a specific resource.
+ */
+export default function createValidator(resource) {
+    const validator = new Validator();
+
+    const schema = dereference(resource.schema, validator);
+    return {
+        validate: (object) => validator.validate(object, schema),
+    };
+}

--- a/src/resource/reference.js
+++ b/src/resource/reference.js
@@ -1,10 +1,19 @@
 import buildVersion from '../versions';
 
 /* A reference to a resource.
+ *
+ * Enables deferal of $ref encoding as late as possible to account for differences
+ * between OpenAPI 2.0 and 3.0.0.
+ *
+ * At the moment, references are required to form a DAG. Cycles will break.
  */
 export default class Reference {
-    constructor(id) {
-        this.id = id;
+    constructor(resource) {
+        this.resource = resource;
+    }
+
+    get id() {
+        return this.resource.id;
     }
 
     build(openapiVersion) {
@@ -12,14 +21,10 @@ export default class Reference {
     }
 
     build20() {
-        return {
-            $ref: `#/definitions/${this.id}`,
-        };
+        return `#/definitions/${this.id}`;
     }
 
     build300() {
-        return {
-            $ref: `#/components/schemas/${this.id}`,
-        };
+        return `#/components/schemas/${this.id}`;
     }
 }

--- a/src/resource/resource.js
+++ b/src/resource/resource.js
@@ -1,19 +1,18 @@
 import ResourceConfig from './config';
+import Reference from './reference';
 
 /* A resource defines a contract for the inputs and outputs of Operations.
  */
 export default class Resource {
     constructor(options = {}) {
-        const { config, registry } = options;
+        const { config } = options;
 
         this.config = config || new ResourceConfig();
-        this.registry = registry || {};
     }
 
     get options() {
         return {
             config: this.config,
-            registry: this.registry,
         };
     }
 
@@ -42,7 +41,7 @@ export default class Resource {
     /* Create a reference to this resource.
      */
     toRef() { // eslint-disable-line class-methods-use-this
-        throw new Error('Resource.toRef() not implemented');
+        return new Reference(this);
     }
 
     /* Validate data according to this resource's definition, returning the valid data.


### PR DESCRIPTION
References (`$ref`) as part of JSON Schema and OpenAPI and are necessary to implement
JSON Schema arrays and invaluable when implementing OpenAPI requests and responses.

However, OpenAPI 2.0 and 3.0.0 encode these references different (because they point
to different locations within the overall spec). As a result, we use a concrete `Reference`
class for all `$ref` instances and resolve it the time we wish to build an OpenAPI spec.

But: we need to resolve these references differently when performing resource validation
(e.g. without the OpenAPI spec). We do so by substituting the `Reference` with a placeholder
schema path and modifying the validator accordingly.