### PR TITLE
Simplify OpenAPI serving

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -6,7 +6,7 @@ export const OPENAPI_3_0_0 = '3.0.0';
 
 export const DEFAULT_CONSUMES = JSON_MIMETYPE;
 export const DEFAULT_DESCRIPTION = 'REST API';
-export const DEFAULT_OPENAPI_VERSION = OPENAPI_2_0;
+export const DEFAULT_OPENAPI_VERSION = OPENAPI_3_0_0;
 export const DEFAULT_PATH = '/';
 export const DEFAULT_PRODUCES = JSON_MIMETYPE;
 export const DEFAULT_SCHEME = 'http';

--- a/src/operation/operation.js
+++ b/src/operation/operation.js
@@ -1,8 +1,8 @@
 import { NO_CONTENT, OK } from 'http-status-codes';
 import { concat } from 'lodash';
 
-import { DEFAULT_CONSUMES, DEFAULT_PRODUCES, OPENAPI_2_0 } from '../constants';
-import buildVersion from '../versions';
+import { DEFAULT_CONSUMES, DEFAULT_PRODUCES, OPENAPI_2_0, OPENAPI_3_0_0 } from '../constants';
+import pickVersion from '../versions';
 import Parameter from './parameter';
 import Response from './response';
 import { JSONSchemaResource } from '../resource';
@@ -101,10 +101,10 @@ export default class Operation {
     /* Build an OpenAPI definition for this operation.
      */
     build(openapiVersion) {
-        return buildVersion(this, openapiVersion);
+        return pickVersion(this, 'build', openapiVersion)();
     }
 
-    build20(openapiVersion) {
+    build20(openapiVersion = OPENAPI_2_0) {
         return {
             consumes: this.hasRequestBody ? [this.consumes || DEFAULT_CONSUMES] : undefined,
             description: this.description,
@@ -116,7 +116,7 @@ export default class Operation {
         };
     }
 
-    build300(openapiVersion) {
+    build300(openapiVersion = OPENAPI_3_0_0) {
         return {
             description: this.description,
             operationId: this.operationId,

--- a/src/operation/parameter.js
+++ b/src/operation/parameter.js
@@ -1,4 +1,6 @@
-import buildVersion from '../versions';
+import pickVersion from '../versions';
+
+import { OPENAPI_2_0 } from '../constants';
 
 /* Defines an OpenAPI parameter.
  */
@@ -12,10 +14,10 @@ export default class Parameter {
     }
 
     build(openapiVersion) {
-        return buildVersion(this, openapiVersion);
+        return pickVersion(this, 'build', openapiVersion)();
     }
 
-    build20(openapiVersion) {
+    build20(openapiVersion = OPENAPI_2_0) {
         return {
             name: this.name,
             in: this.parameterType,

--- a/src/operation/response.js
+++ b/src/operation/response.js
@@ -1,9 +1,9 @@
 import { NO_CONTENT } from 'http-status-codes';
 import { mapValues } from 'lodash';
 
-import { JSON_MIMETYPE } from '../constants';
+import { JSON_MIMETYPE, OPENAPI_2_0, OPENAPI_3_0_0 } from '../constants';
 import FileType from '../resource/file';
-import buildVersion from '../versions';
+import pickVersion from '../versions';
 
 /* Represents an OpenAPI Response.
  */
@@ -18,10 +18,10 @@ export default class Response {
     }
 
     build(openapiVersion) {
-        return buildVersion(this, openapiVersion);
+        return pickVersion(this, 'build', openapiVersion)();
     }
 
-    build20(openapiVersion) {
+    build20(openapiVersion = OPENAPI_2_0) {
         return {
             [this.name]: {
                 description: this.description,
@@ -30,7 +30,7 @@ export default class Response {
         };
     }
 
-    build300(openapiVersion) {
+    build300(openapiVersion = OPENAPI_3_0_0) {
         return {
             [this.name]: {
                 description: this.description,

--- a/src/resource/file.js
+++ b/src/resource/file.js
@@ -1,10 +1,10 @@
-import buildVersion from '../versions';
+import pickVersion from '../versions';
 
 /* The type for a resource that uses a file.
  */
 export default class FileType {
     build(openapiVersion) {
-        return buildVersion(this, openapiVersion);
+        return pickVersion(this, 'build', openapiVersion)();
     }
 
     build20() { // eslint-disable-line class-methods-use-this

--- a/src/resource/reference.js
+++ b/src/resource/reference.js
@@ -1,4 +1,4 @@
-import buildVersion from '../versions';
+import pickVersion from '../versions';
 
 /* A reference to a resource.
  *
@@ -17,7 +17,7 @@ export default class Reference {
     }
 
     build(openapiVersion) {
-        return buildVersion(this, openapiVersion);
+        return pickVersion(this, 'build', openapiVersion)();
     }
 
     build20() {

--- a/src/spec/index.js
+++ b/src/spec/index.js
@@ -4,8 +4,8 @@ import Info from './info';
 import Server from './server';
 import Spec from './spec';
 
-function buildSpec({ info, openapiVersion, operations, server, ...more }) {
-    const spec = new Spec({
+function buildSpec({ info, operations, server, ...options }) {
+    return new Spec({
         info,
         operations: flatten(concat(
             operations.map(
@@ -13,16 +13,13 @@ function buildSpec({ info, openapiVersion, operations, server, ...more }) {
             ),
         )),
         server,
-        ...more,
+        ...options,
     });
-    return spec.build(openapiVersion);
 }
 
-function serveSpec(options) {
+function serveSpec({ openapiVersion, ...options }) {
     const spec = buildSpec(options);
-    return (req, res) => {
-        res.status(200).send(spec);
-    };
+    return spec.serve(openapiVersion);
 }
 
 export {

--- a/src/versions.js
+++ b/src/versions.js
@@ -1,11 +1,21 @@
+import { get } from 'lodash';
+
 import { OPENAPI_2_0, OPENAPI_3_0_0 } from './constants';
 
-export default function buildVersion(self, openapiVersion) {
-    if (openapiVersion === OPENAPI_2_0) {
-        return self.build20(openapiVersion);
+export default function pickVersion(self, name, openapiVersion) {
+    let suffix;
+    switch (openapiVersion) {
+        case OPENAPI_2_0:
+            suffix = '20';
+            break;
+        case OPENAPI_3_0_0:
+            suffix = '300';
+            break;
+        default:
+            throw new Error(`OpenAPI ${openapiVersion} is not supported`);
     }
-    if (openapiVersion === OPENAPI_3_0_0) {
-        return self.build300(openapiVersion);
-    }
-    throw new Error(`OpenAPI ${openapiVersion} is not supported`);
+
+    const funcName = `${name}${suffix}`;
+    const func = get(self, funcName);
+    return func.bind(self);
 }


### PR DESCRIPTION
We have been conflating building a spec (which needs to happen once)
with serving a spec (which needs to choose a version). The solution is
to enable the spec itself to act as the express route that serves itself.

In the process, generalize the version switching code to handle this case
in addition to the cases that build a spec into OpenAPI by version.