### PR TITLE
Add JSONSchemaResource.choice() static factory

### DIFF
--- a/src/__tests__/__snapshots__/polymorphic.test.js.snap
+++ b/src/__tests__/__snapshots__/polymorphic.test.js.snap
@@ -1,0 +1,308 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`polymorphic schema openapi 2.0 is valid 1`] = `
+Object {
+  "basePath": "/",
+  "definitions": Object {
+    "Error": Object {
+      "properties": Object {
+        "message": Object {
+          "type": "string",
+          "x-nullable": false,
+        },
+        "status": Object {
+          "type": "integer",
+          "x-nullable": false,
+        },
+      },
+      "type": "object",
+    },
+    "Pet": Object {
+      "properties": Object {
+        "info": Object {
+          "$ref": "#/definitions/PetInfo",
+        },
+        "name": Object {
+          "type": "string",
+          "x-nullable": false,
+        },
+        "type": Object {
+          "enum": Array [
+            "cat",
+            "dog",
+            "unicorn",
+          ],
+          "type": "string",
+          "x-nullable": false,
+        },
+      },
+      "required": Array [
+        "name",
+        "type",
+        "info",
+      ],
+      "type": "object",
+    },
+    "PetList": Object {
+      "properties": Object {
+        "count": Object {
+          "type": "integer",
+          "x-nullable": false,
+        },
+        "items": Object {
+          "items": Object {
+            "$ref": "#/definitions/Pet",
+          },
+          "type": "array",
+          "x-nullable": false,
+        },
+        "limit": Object {
+          "type": "integer",
+          "x-nullable": false,
+        },
+        "offset": Object {
+          "type": "integer",
+          "x-nullable": false,
+        },
+      },
+      "required": Array [
+        "items",
+        "count",
+      ],
+      "type": "object",
+    },
+  },
+  "info": Object {
+    "description": "REST API",
+    "title": "REST API",
+    "version": "0.1.0",
+  },
+  "paths": Object {
+    "/pet": Object {
+      "get": Object {
+        "operationId": "search",
+        "parameters": Array [],
+        "produces": Array [
+          "application/json",
+        ],
+        "responses": Object {
+          "200": Object {
+            "description": "PetList as JSON",
+            "schema": Object {
+              "$ref": "#/definitions/PetList",
+            },
+          },
+          "default": Object {
+            "description": "An error occurred",
+            "schema": Object {
+              "$ref": "#/definitions/Error",
+            },
+          },
+        },
+        "tags": Array [
+          "pet",
+        ],
+      },
+      "post": Object {
+        "consumes": Array [
+          "application/json",
+        ],
+        "operationId": "create",
+        "parameters": Array [
+          Object {
+            "in": "body",
+            "name": "pet",
+            "required": true,
+            "schema": Object {
+              "$ref": "#/definitions/Pet",
+            },
+          },
+        ],
+        "produces": Array [
+          "application/json",
+        ],
+        "responses": Object {
+          "201": Object {
+            "description": "Pet as JSON",
+            "schema": Object {
+              "$ref": "#/definitions/Pet",
+            },
+          },
+          "default": Object {
+            "description": "An error occurred",
+            "schema": Object {
+              "$ref": "#/definitions/Error",
+            },
+          },
+        },
+        "tags": Array [
+          "pet",
+        ],
+      },
+    },
+  },
+  "schemes": Array [
+    "http",
+  ],
+  "swagger": "2.0",
+}
+`;
+
+exports[`polymorphic schema openapi 3.0.0 is valid 1`] = `
+Object {
+  "components": Object {
+    "schemas": Object {
+      "Error": Object {
+        "properties": Object {
+          "message": Object {
+            "nullable": false,
+            "type": "string",
+          },
+          "status": Object {
+            "nullable": false,
+            "type": "integer",
+          },
+        },
+        "type": "object",
+      },
+      "Pet": Object {
+        "properties": Object {
+          "info": Object {
+            "$ref": "#/components/schemas/PetInfo",
+          },
+          "name": Object {
+            "nullable": false,
+            "type": "string",
+          },
+          "type": Object {
+            "enum": Array [
+              "cat",
+              "dog",
+              "unicorn",
+            ],
+            "nullable": false,
+            "type": "string",
+          },
+        },
+        "required": Array [
+          "name",
+          "type",
+          "info",
+        ],
+        "type": "object",
+      },
+      "PetList": Object {
+        "properties": Object {
+          "count": Object {
+            "nullable": false,
+            "type": "integer",
+          },
+          "items": Object {
+            "items": Object {
+              "$ref": "#/components/schemas/Pet",
+            },
+            "nullable": false,
+            "type": "array",
+          },
+          "limit": Object {
+            "nullable": false,
+            "type": "integer",
+          },
+          "offset": Object {
+            "nullable": false,
+            "type": "integer",
+          },
+        },
+        "required": Array [
+          "items",
+          "count",
+        ],
+        "type": "object",
+      },
+    },
+  },
+  "info": Object {
+    "description": "REST API",
+    "title": "REST API",
+    "version": "0.1.0",
+  },
+  "openapi": "3.0.0",
+  "paths": Object {
+    "/pet": Object {
+      "get": Object {
+        "operationId": "search",
+        "parameters": Array [],
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "$ref": "#/components/schemas/PetList",
+                },
+              },
+            },
+            "description": "PetList as JSON",
+          },
+          "default": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "$ref": "#/components/schemas/Error",
+                },
+              },
+            },
+            "description": "An error occurred",
+          },
+        },
+        "tags": Array [
+          "pet",
+        ],
+      },
+      "post": Object {
+        "operationId": "create",
+        "parameters": Array [],
+        "requestBody": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "$ref": "#/components/schemas/Pet",
+              },
+            },
+          },
+          "required": true,
+        },
+        "responses": Object {
+          "201": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "$ref": "#/components/schemas/Pet",
+                },
+              },
+            },
+            "description": "Pet as JSON",
+          },
+          "default": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "$ref": "#/components/schemas/Error",
+                },
+              },
+            },
+            "description": "An error occurred",
+          },
+        },
+        "tags": Array [
+          "pet",
+        ],
+      },
+    },
+  },
+  "servers": Array [
+    Object {
+      "url": "/",
+    },
+  ],
+}
+`;

--- a/src/__tests__/__snapshots__/reference.test.js.snap
+++ b/src/__tests__/__snapshots__/reference.test.js.snap
@@ -1,6 +1,186 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`polymorphic schema search returns a list of parents with references to children 1`] = `
+exports[`schema references openapi 2.0 is valid 1`] = `
+Object {
+  "basePath": "/",
+  "definitions": Object {
+    "Error": Object {
+      "properties": Object {
+        "message": Object {
+          "type": "string",
+          "x-nullable": false,
+        },
+        "status": Object {
+          "type": "integer",
+          "x-nullable": false,
+        },
+      },
+      "type": "object",
+    },
+    "ParentList": Object {
+      "properties": Object {
+        "count": Object {
+          "type": "integer",
+          "x-nullable": false,
+        },
+        "items": Object {
+          "items": Object {
+            "$ref": "#/definitions/Parent",
+          },
+          "type": "array",
+          "x-nullable": false,
+        },
+        "limit": Object {
+          "type": "integer",
+          "x-nullable": false,
+        },
+        "offset": Object {
+          "type": "integer",
+          "x-nullable": false,
+        },
+      },
+      "required": Array [
+        "items",
+        "count",
+      ],
+      "type": "object",
+    },
+  },
+  "info": Object {
+    "description": "REST API",
+    "title": "REST API",
+    "version": "0.1.0",
+  },
+  "paths": Object {
+    "/parent": Object {
+      "get": Object {
+        "operationId": "search",
+        "parameters": Array [],
+        "produces": Array [
+          "application/json",
+        ],
+        "responses": Object {
+          "200": Object {
+            "description": "ParentList as JSON",
+            "schema": Object {
+              "$ref": "#/definitions/ParentList",
+            },
+          },
+          "default": Object {
+            "description": "An error occurred",
+            "schema": Object {
+              "$ref": "#/definitions/Error",
+            },
+          },
+        },
+        "tags": Array [
+          "Parent",
+        ],
+      },
+    },
+  },
+  "schemes": Array [
+    "http",
+  ],
+  "swagger": "2.0",
+}
+`;
+
+exports[`schema references openapi 3.0.0 is valid 1`] = `
+Object {
+  "components": Object {
+    "schemas": Object {
+      "Error": Object {
+        "properties": Object {
+          "message": Object {
+            "nullable": false,
+            "type": "string",
+          },
+          "status": Object {
+            "nullable": false,
+            "type": "integer",
+          },
+        },
+        "type": "object",
+      },
+      "ParentList": Object {
+        "properties": Object {
+          "count": Object {
+            "nullable": false,
+            "type": "integer",
+          },
+          "items": Object {
+            "items": Object {
+              "$ref": "#/components/schemas/Parent",
+            },
+            "nullable": false,
+            "type": "array",
+          },
+          "limit": Object {
+            "nullable": false,
+            "type": "integer",
+          },
+          "offset": Object {
+            "nullable": false,
+            "type": "integer",
+          },
+        },
+        "required": Array [
+          "items",
+          "count",
+        ],
+        "type": "object",
+      },
+    },
+  },
+  "info": Object {
+    "description": "REST API",
+    "title": "REST API",
+    "version": "0.1.0",
+  },
+  "openapi": "3.0.0",
+  "paths": Object {
+    "/parent": Object {
+      "get": Object {
+        "operationId": "search",
+        "parameters": Array [],
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "$ref": "#/components/schemas/ParentList",
+                },
+              },
+            },
+            "description": "ParentList as JSON",
+          },
+          "default": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "$ref": "#/components/schemas/Error",
+                },
+              },
+            },
+            "description": "An error occurred",
+          },
+        },
+        "tags": Array [
+          "Parent",
+        ],
+      },
+    },
+  },
+  "servers": Array [
+    Object {
+      "url": "/",
+    },
+  ],
+}
+`;
+
+exports[`schema references search returns a list of parents with references to children 1`] = `
 Object {
   "count": 3,
   "items": Array [

--- a/src/__tests__/openapi.test.js
+++ b/src/__tests__/openapi.test.js
@@ -1,24 +1,17 @@
-import { readFileSync } from 'fs';
-import { Validator } from 'jsonschema';
 import request from 'supertest';
 
 import createApp from './app';
+import validator, { openapi2, openapi3 } from './validate';
 
 describe('app', () => {
-    const openapi2 = JSON.parse(readFileSync('schemas/openapi/2.0/schema.json'));
-    const openapi3 = JSON.parse(readFileSync('schemas/openapi/3.0/schema.json'));
-    const jsonSchema = JSON.parse(readFileSync('schemas/json-schema/draft-04/schema.json'));
-    const validator = new Validator();
-    validator.addSchema(jsonSchema);
-
     describe('OpenAPI', () => {
         describe('2.0', () => {
             it('returns 200', async () => {
                 const app = createApp();
                 const response = await request(app).get('/openapi/2.0');
                 expect(response.statusCode).toEqual(200);
-                expect(response.body).toMatchSnapshot();
                 validator.validate(response.body, openapi2, { throwError: true });
+                expect(response.body).toMatchSnapshot();
             });
         });
         describe('3.0.0', () => {
@@ -26,8 +19,8 @@ describe('app', () => {
                 const app = createApp();
                 const response = await request(app).get('/openapi/3.0.0');
                 expect(response.statusCode).toEqual(200);
-                expect(response.body).toMatchSnapshot();
                 validator.validate(response.body, openapi3, { throwError: true });
+                expect(response.body).toMatchSnapshot();
             });
         });
     });

--- a/src/__tests__/polymorphic.js
+++ b/src/__tests__/polymorphic.js
@@ -5,6 +5,7 @@ import { JSONSchemaResource } from '..';
 export const PetType = Object.freeze({
     cat: 'cat',
     dog: 'dog',
+    unicorn: 'unicorn',
 });
 
 export const CatInfo = JSONSchemaResource.all({
@@ -25,6 +26,14 @@ export const DogInfo = JSONSchemaResource.all({
     },
 });
 
+export const PetInfo = JSONSchemaResource.choice({
+    id: 'PetInfo',
+    resources: [
+        CatInfo,
+        DogInfo,
+    ],
+});
+
 export const Pet = JSONSchemaResource.all({
     id: 'Pet',
     properties: {
@@ -36,14 +45,7 @@ export const Pet = JSONSchemaResource.all({
             enum: Object.keys(PetType).sort(),
         },
         info: {
-            anyOf: [
-                {
-                    $ref: CatInfo.toRef(),
-                },
-                {
-                    $ref: DogInfo.toRef(),
-                },
-            ],
+            $ref: PetInfo.toRef(),
         },
     },
 });

--- a/src/__tests__/polymorphic.test.js
+++ b/src/__tests__/polymorphic.test.js
@@ -3,6 +3,7 @@ import request from 'supertest';
 import { Namespace } from '..';
 import { newApp } from './app';
 import { Pet, PetType } from './polymorphic';
+import validator, { openapi2, openapi3 } from './validate';
 
 function create(pet) {
     return pet;
@@ -118,6 +119,34 @@ describe('polymorphic schema', () => {
                 type: PetType.dog,
             });
             expect(response.statusCode).toEqual(422);
+        });
+        it('validates unicorns', async () => {
+            const response = await request(app).post('/pet').send({
+                info: {
+                    // we intentionally do not UnicornInfo
+                },
+                name: 'Amalthea',
+                type: PetType.unicorn,
+            });
+            expect(response.statusCode).toEqual(422);
+        });
+    });
+
+    describe('openapi 2.0', () => {
+        it('is valid', async () => {
+            const response = await request(app).get('/openapi/2.0');
+            expect(response.statusCode).toEqual(200);
+            validator.validate(response.body, openapi2, { throwError: true });
+            expect(response.body).toMatchSnapshot();
+        });
+    });
+
+    describe('openapi 3.0.0', () => {
+        it('is valid', async () => {
+            const response = await request(app).get('/openapi/3.0.0');
+            expect(response.statusCode).toEqual(200);
+            validator.validate(response.body, openapi3, { throwError: true });
+            expect(response.body).toMatchSnapshot();
         });
     });
 });

--- a/src/__tests__/reference.test.js
+++ b/src/__tests__/reference.test.js
@@ -3,6 +3,7 @@ import request from 'supertest';
 import { Namespace } from '..';
 import { newApp } from './app';
 import { Parent } from './reference';
+import validator, { openapi2, openapi3 } from './validate';
 
 function search() {
     return {
@@ -32,7 +33,7 @@ function search() {
     };
 }
 
-describe('polymorphic schema', () => {
+describe('schema references', () => {
     const operation = new Namespace('Parent')
         .search({ output: Parent.toList(), route: search });
 
@@ -44,6 +45,24 @@ describe('polymorphic schema', () => {
 
             expect(response.statusCode).toEqual(200);
             expect(response.body.items.length).toEqual(3);
+            expect(response.body).toMatchSnapshot();
+        });
+    });
+
+    describe('openapi 2.0', () => {
+        it('is valid', async () => {
+            const response = await request(app).get('/openapi/2.0');
+            expect(response.statusCode).toEqual(200);
+            validator.validate(response.body, openapi2, { throwError: true });
+            expect(response.body).toMatchSnapshot();
+        });
+    });
+
+    describe('openapi 3.0.0', () => {
+        it('is valid', async () => {
+            const response = await request(app).get('/openapi/3.0.0');
+            expect(response.statusCode).toEqual(200);
+            validator.validate(response.body, openapi3, { throwError: true });
             expect(response.body).toMatchSnapshot();
         });
     });

--- a/src/__tests__/validate.js
+++ b/src/__tests__/validate.js
@@ -1,0 +1,11 @@
+import { readFileSync } from 'fs';
+import { Validator } from 'jsonschema';
+
+export const openapi2 = JSON.parse(readFileSync('schemas/openapi/2.0/schema.json'));
+export const openapi3 = JSON.parse(readFileSync('schemas/openapi/3.0/schema.json'));
+export const jsonSchema = JSON.parse(readFileSync('schemas/json-schema/draft-04/schema.json'));
+
+const validator = new Validator();
+validator.addSchema(jsonSchema);
+
+export default validator;


### PR DESCRIPTION
Creating a JSONSchema choice that validates and works with the nodejs jsonschema
library is a little tricky:

 - JSONSchema draft-04 does not allow `oneOf` or `allOf` in properties, so we
   **cannot** use:

       {
          "properties": {
             "foo": {
                "oneOf": [
                   { "$ref": "#foo" },
                   { "$ref": "#bar" }
                ]
             }
           }
       }

 -  Our use of the nodejs schemaschema library tends to disallow additional
    properties, so we **cannot** simply make a new type to reference in our
    `foo` property:

       {
          "id": "ChoiceType",
          "oneOf": [
             { "$ref": "#foo" },
             { "$ref": "#bar" }
          ]
       }

The solution is to do something like the latter but add a union of properties
for all referenced types. We add a convenience function to do so.